### PR TITLE
Add customizable armor layers and skin selectors

### DIFF
--- a/wow-pvp-duel-game.html
+++ b/wow-pvp-duel-game.html
@@ -52,6 +52,14 @@
             <div class="control-item"><strong>Jump:</strong> Space</div>
             <div class="control-item"><strong>Abilities:</strong> 1-7</div>
             <div class="control-item"><strong>Target:</strong> Tab</div>
+            <div class="control-item">
+                <label for="playerSkinSelect"><strong>Rogue Skin:</strong></label>
+                <select id="playerSkinSelect"></select>
+            </div>
+            <div class="control-item">
+                <label for="enemySkinSelect"><strong>Mage Skin:</strong></label>
+                <select id="enemySkinSelect"></select>
+            </div>
         </div>
 
         <div id="overlayContainer">


### PR DESCRIPTION
## Summary
- add reusable texture loading helpers and appearance definitions for player and enemy skins
- attach new hood, shoulder, and belt meshes to character skeletons so armor moves with animations
- provide UI dropdowns and game state helpers to switch between available skin sets during play

## Testing
- no automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d24068e7288329ae0b734938c682bd